### PR TITLE
Feature/hashin

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import ConfirmEmail from "./ConfirmEmail";
 import SignIn from "./SignIn";
 import SignUp from "./SignUp";
 import SetupWorkspace from "./SetupWorkspace";
+import SetupChannel from "./SetupChannel";
 import Workspaces from "./Workspaces";
 import "./css/App.css";
 
@@ -15,6 +16,7 @@ function App() {
         <Route path="/ConfirmEmail" element={<ConfirmEmail />} />
         <Route path="/Workspaces" element={<Workspaces />} />
         <Route path="/SetupWorkspace" element={<SetupWorkspace />} />
+        <Route path="/SetupChannel" element={<SetupChannel />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/SetupChannel.js
+++ b/src/SetupChannel.js
@@ -1,0 +1,8 @@
+import React from "react";
+import "./css/SetupWorkspace.css";
+
+function SetupChannel() {
+  return <div>채널 만드는 페이지</div>;
+}
+
+export default SetupChannel;

--- a/src/SetupChannel.js
+++ b/src/SetupChannel.js
@@ -1,15 +1,18 @@
 import axios from "axios";
 import React, { useState, useEffect } from "react";
 import { FiAlertTriangle } from "react-icons/fi";
+import { useNavigate } from "react-router-dom";
+
 import "./css/SetupWorkspace.css";
 
 function SetupChannel() {
   const [teamName, setTeamName] = useState("새 워크스페이스");
   const [channelName, setChannelName] = useState("");
-  const [charcount, setCharCount] = useState(10);
+  const [charcount, setCharCount] = useState(80);
   const [isAlert, setIsAlert] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
   const [validation, setValidation] = useState("EMPTY");
+  const navigate = useNavigate();
 
   const handleInputFocus = () => {
     setIsVisible(true);
@@ -21,7 +24,7 @@ function SetupChannel() {
 
   const handleValidate = (e) => {
     const lencount = e.target.value.length;
-    const maxLength = 10;
+    const maxLength = 80;
 
     setChannelName(e.target.value);
     setCharCount(maxLength - lencount);
@@ -39,6 +42,10 @@ function SetupChannel() {
   useEffect(() => {
     console.log(`ch_name: ${channelName}`);
   }, [channelName]);
+
+  const GotoSetupWorkspace = (e) => {
+    navigate("/setUpWorkspace");
+  };
 
   //입력된 워크스페이스 이름 db저장
   // const handleContinue = (e) => {
@@ -262,13 +269,21 @@ function SetupChannel() {
                                   className="c-alert__message"
                                   data-qa-alert-message="true"
                                 >
-                                  10 자까지만 입력할 수 있습니다.
+                                  80 자까지만 입력할 수 있습니다.
                                 </span>
                               </div>
                             ) : null}
                           </div>
                         </div>
-                        <button>이전</button>
+                        <button
+                          className="c-button c-button--primary c-button--large p-setup_page__content_button p-setup_page__content_button--aubergine margin_top_300 margin_right"
+                          data-qa="setup-page-team-name-submit"
+                          aria-label="이전 단계로 이동"
+                          type="submit"
+                          onClick={GotoSetupWorkspace}
+                        >
+                          이전
+                        </button>
                         <button
                           className="c-button c-button--primary c-button--large p-setup_page__content_button p-setup_page__content_button--aubergine margin_top_300"
                           data-qa="setup-page-team-name-submit"

--- a/src/SetupChannel.js
+++ b/src/SetupChannel.js
@@ -1,8 +1,298 @@
-import React from "react";
+import axios from "axios";
+import React, { useState, useEffect } from "react";
+import { FiAlertTriangle } from "react-icons/fi";
 import "./css/SetupWorkspace.css";
 
 function SetupChannel() {
-  return <div>채널 만드는 페이지</div>;
+  const [teamName, setTeamName] = useState("새 워크스페이스");
+  const [channelName, setChannelName] = useState("");
+  const [charcount, setCharCount] = useState(50);
+  const [isAlert, setIsAlert] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const [validation, setValidation] = useState("EMPTY");
+
+  const handleInputFocus = () => {
+    setIsVisible(true);
+  };
+
+  const handleInputBlur = () => {
+    setIsVisible(false);
+  };
+
+  const handleValidate = (e) => {
+    const lencount = e.target.value.length;
+    const maxLength = 80;
+
+    setChannelName(e.target.value);
+    setCharCount(maxLength - lencount);
+
+    if (lencount > maxLength) {
+      setIsAlert(true);
+      setValidation("INVALID");
+    } else if (lencount === 0) {
+      setValidation("EMPTY");
+    } else {
+      setIsAlert(false);
+      setValidation("VALID");
+    }
+  };
+  useEffect(() => {
+    console.log(`ch_name: ${channelName}`);
+  }, [channelName]);
+
+  //입력된 워크스페이스 이름 db저장
+  // const handleContinue = (e) => {
+  //   e.preventDefault();
+  //   if(validation === "VALID") {
+  //     axios({
+  //       method: "post",
+  //       url: "",
+  //       data: { ws_name: teamName},
+  //     }).then({
+  //       navigate("/SetupChannel", {
+  //         state: {ws_name: teamName},
+  //       });
+  //     });
+  //   };
+  // };
+
+  return (
+    <div className="app_root">
+      <div className="p-client_container">
+        <div className="p-client">
+          <div className="p-top_nav"></div>
+          <div className="p-workspace-layout">
+            {/* 워크스페이스 셋업 사이드 바 */}
+            <div className="p-workspace__sidebar p-workspace__sidebar--tiny">
+              <div
+                className="p-workspace__channel_sidebar"
+                data-qa="ws_channel_sidebar"
+              >
+                <div
+                  className="p-ia__sidebar_header p-ia__sidebar_header--top-nav p-ia__sidebar_header--v-team-creation-view p-ia__sidebar_header--ia_details_popover"
+                  data-qa="minimal-header"
+                >
+                  <div
+                    data-qa="sidebar_header_button"
+                    className="p-ia__sidebar_header__button p-ia__sidebar_header__button--setup_team_name"
+                  >
+                    <div className="p-ia__sidebar_header__info">
+                      <div className="p-ia__sidebar_header__team_name">
+                        {/* 워크스페이스 이름 */}
+                        <span className="p-ia__sidebar_header__team_name_text">
+                          {teamName}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <nav
+                  data-qa-channel-sidebar="true"
+                  className="p-channel_sidebar p-channel_sidebar--classic_nav p-channel_sidebar--iap1"
+                >
+                  <div className="p-channel_sidebar__list">
+                    <div role="application">
+                      <div
+                        role="presentation"
+                        className="c-virtual_list c-virtual_list--scrollbar p-channel_sidebar__static_list c-scrollbar c-scrollbar--hidden"
+                      >
+                        <div
+                          data-qa="slack_kit_scrollbar"
+                          role="presentation"
+                          className="c-scrollbar__hider"
+                        >
+                          <div
+                            role="presentation"
+                            className="c-scrollbar__child"
+                          >
+                            <div
+                              data-qa="slack_kit_list"
+                              className="c-virtual_list__scroll_container"
+                              role="list"
+                              aria-label="선택한 채널 검색"
+                            >
+                              <div
+                                className="c-virtual_list__item"
+                                tabIndex={0}
+                                role="listitem"
+                                id="channel-heading"
+                                data-qa="virtual-list-item"
+                                style={{ top: "0px" }}
+                              >
+                                <div className="p-channel_sidebar__static_list__item">
+                                  <div className="p-channel_sidebar__section_heading p-channel_sidebar__section_heading--setup-sidebar margin_top_200">
+                                    <div
+                                      className="p-channel_sidebar__section_heading_label p-channel_sidebar__section_heading_label--setup"
+                                      tabindex="0"
+                                      role="presentation"
+                                      aria-label="선택한 채널 섹션"
+                                    >
+                                      채널
+                                    </div>
+                                  </div>
+                                </div>
+                                {/* ... */}
+                                <div
+                                  className="c-virtual_list__item"
+                                  tabindex="-1"
+                                  role="listitem"
+                                  id="56193dcc-0ab0-4cff-a2e2-dd2de86b166b"
+                                  data-qa="virtual-list-item"
+                                  style={{ top: "68px" }}
+                                >
+                                  <div
+                                    className="p-channel_sidebar__static_list__item"
+                                    data-qa="team_setup_sidebar_channel_link_project"
+                                  >
+                                    <div className="p-channel_sidebar__channel p-channel_sidebar__channel--setup">
+                                      <span className="p-channel_sidebar__name">
+                                        # {channelName}
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+
+                                {/* ... */}
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div role="presentation" className="c-scrollbar__track">
+                          <div
+                            role="presentation"
+                            className="c-scrollbar__bar"
+                            tabIndex="-1"
+                          ></div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </nav>
+              </div>
+            </div>
+
+            {/* 워크스페이스 셋업단 */}
+            <div
+              role="main"
+              aria-label="채널 설정"
+              className="p-workspace__primary_view"
+            >
+              <div className="p-workspace__primary_view_contents">
+                <div className="p-setup_page">
+                  <div className="p-setup_page__content">
+                    <div
+                      data-qa="team_setup_step_counter"
+                      className="p-setup_page__steps_counter"
+                    >
+                      2/2단계
+                    </div>
+                    <div className="p-autoclog__hook">
+                      <form>
+                        <h2 className="p-setup_page__header p-setup_page__header--has-subheader">
+                          현재 고객님의 팀은 어떤 일을 진행하고 계시나요?
+                        </h2>
+                        <p className="p-setup_page__subheader p-setup_page__subheader--deprecated-margin">
+                          프로젝트, 캠페인, 이벤트 또는 성사하려는 거래 등
+                          무엇이든 될 수 있습니다.
+                        </p>
+
+                        <span id="channels-input-desc" className="offscreen">
+                          프로젝트 이름, 예: Q4 예산, 가을 캠페인
+                        </span>
+                        <div data-qa-formtext="true">
+                          <div
+                            role="presentation"
+                            className="c-input_character_count c-input_character_count--large"
+                            data-qa="input_character_count"
+                          >
+                            <input
+                              data-qa="team_setup_channel_name_input"
+                              aria-describedby="channels-input-desc setup-channel-name-input_hint setup-channel-name-input_character-count"
+                              aria-invalid="false"
+                              aria-required="false"
+                              aria-label=""
+                              autoComplete="off"
+                              className={`${
+                                isAlert ? "margin_bottom_0" : ""
+                              } c-input_text c-input_text--large`}
+                              id="setup-channel-name-input"
+                              name="setup-channel-name-input"
+                              placeholder="예: 4분기 예산, 가을 캠페인"
+                              type="text"
+                              value={channelName}
+                              onChange={handleValidate}
+                              onFocus={handleInputFocus}
+                              onBlur={handleInputBlur}
+                              style={{ paddingRight: "42px" }}
+                            />
+
+                            {isVisible ? (
+                              <div
+                                aria-hidden="true"
+                                className="c-input_character_count__characters-remaining"
+                                style={
+                                  charcount > -1
+                                    ? { color: "gray" }
+                                    : { color: "#e01e5a" }
+                                }
+                              >
+                                {charcount}
+                              </div>
+                            ) : null}
+
+                            {isAlert && validation === "INVALID" ? (
+                              <div
+                                className="c-alert c-alert--nested_box c-alert--level_error c-alert--align_left margin_bottom_100"
+                                id="setup-page-team-name_error"
+                                data-qa-alert="true"
+                                data-qa-alert-level="error"
+                                data-qa-alert-type="nested_box"
+                                data-qa-alert-align="left"
+                              >
+                                <i
+                                  className="c-icon c-alert__icon c-icon--warning c-icon--inherit c-icon--inline"
+                                  type="warning"
+                                  data-qa-alert-icon="true"
+                                  data-qa-alert-icon-type="warning"
+                                  aria-hidden="true"
+                                >
+                                  <FiAlertTriangle color="red" size="17" />
+                                </i>
+                                <span
+                                  className="c-alert__message"
+                                  data-qa-alert-message="true"
+                                >
+                                  80 자까지만 입력할 수 있습니다.
+                                </span>
+                              </div>
+                            ) : null}
+                          </div>
+                        </div>
+                        <button
+                          className="c-button c-button--primary c-button--large p-setup_page__content_button p-setup_page__content_button--aubergine margin_top_300"
+                          data-qa="setup-page-team-name-submit"
+                          aria-label="다음 단계로 이동"
+                          type="submit"
+                          disabled={`${
+                            (isAlert && validation === "INVALID") ||
+                            validation === "EMPTY"
+                              ? "disabled"
+                              : ""
+                          }`}
+                        >
+                          다음
+                        </button>
+                      </form>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default SetupChannel;

--- a/src/SetupChannel.js
+++ b/src/SetupChannel.js
@@ -6,7 +6,7 @@ import "./css/SetupWorkspace.css";
 function SetupChannel() {
   const [teamName, setTeamName] = useState("새 워크스페이스");
   const [channelName, setChannelName] = useState("");
-  const [charcount, setCharCount] = useState(50);
+  const [charcount, setCharCount] = useState(10);
   const [isAlert, setIsAlert] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
   const [validation, setValidation] = useState("EMPTY");
@@ -21,7 +21,7 @@ function SetupChannel() {
 
   const handleValidate = (e) => {
     const lencount = e.target.value.length;
-    const maxLength = 80;
+    const maxLength = 10;
 
     setChannelName(e.target.value);
     setCharCount(maxLength - lencount);
@@ -123,7 +123,7 @@ function SetupChannel() {
                                   <div className="p-channel_sidebar__section_heading p-channel_sidebar__section_heading--setup-sidebar margin_top_200">
                                     <div
                                       className="p-channel_sidebar__section_heading_label p-channel_sidebar__section_heading_label--setup"
-                                      tabindex="0"
+                                      tabIndex="0"
                                       role="presentation"
                                       aria-label="선택한 채널 섹션"
                                     >
@@ -134,7 +134,7 @@ function SetupChannel() {
                                 {/* ... */}
                                 <div
                                   className="c-virtual_list__item"
-                                  tabindex="-1"
+                                  tabIndex="-1"
                                   role="listitem"
                                   id="56193dcc-0ab0-4cff-a2e2-dd2de86b166b"
                                   data-qa="virtual-list-item"
@@ -262,12 +262,13 @@ function SetupChannel() {
                                   className="c-alert__message"
                                   data-qa-alert-message="true"
                                 >
-                                  80 자까지만 입력할 수 있습니다.
+                                  10 자까지만 입력할 수 있습니다.
                                 </span>
                               </div>
                             ) : null}
                           </div>
                         </div>
+                        <button>이전</button>
                         <button
                           className="c-button c-button--primary c-button--large p-setup_page__content_button p-setup_page__content_button--aubergine margin_top_300"
                           data-qa="setup-page-team-name-submit"

--- a/src/SetupWorkspace.js
+++ b/src/SetupWorkspace.js
@@ -6,7 +6,7 @@ import "./css/SetupWorkspace.css";
 
 function SetupWorkspace() {
   const [teamName, setTeamName] = useState("새 워크스페이스");
-  const [charcount, setCharCount] = useState(50);
+  const [charcount, setCharCount] = useState(10);
   const [isAlert, setIsAlert] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
   const [validation, setValidation] = useState("VALID");
@@ -22,7 +22,7 @@ function SetupWorkspace() {
 
   const handleValidate = (e) => {
     const lencount = e.target.value.length;
-    const maxLength = 50;
+    const maxLength = 10;
 
     setTeamName(e.target.value);
     setCharCount(maxLength - lencount);
@@ -41,7 +41,15 @@ function SetupWorkspace() {
     console.log(`ws_name: ${teamName}`);
   }, [teamName]);
 
+  // workspaceName localstorage에 저장
+  const saveWorkspaceName = () => {
+    const workspaceName = { ws_name: teamName };
+    window.localStorage.setItem("ws_name", JSON.stringify(workspaceName));
+  };
+
   const GotoSetupChannel = (e) => {
+    saveWorkspaceName(e);
+    // window.localStorage.getItem("teamName");
     navigate("/setUpChannel");
   };
 
@@ -226,7 +234,7 @@ function SetupWorkspace() {
                                   className="c-alert__message"
                                   data-qa-alert-message="true"
                                 >
-                                  50 자까지만 입력할 수 있습니다.
+                                  10 자까지만 입력할 수 있습니다.
                                 </span>
                               </div>
                             ) : null}

--- a/src/SetupWorkspace.js
+++ b/src/SetupWorkspace.js
@@ -6,12 +6,13 @@ import "./css/SetupWorkspace.css";
 
 function SetupWorkspace() {
   const [teamName, setTeamName] = useState("새 워크스페이스");
-  const [charcount, setCharCount] = useState(10);
+  const [charcount, setCharCount] = useState(42);
   const [isAlert, setIsAlert] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
   const [validation, setValidation] = useState("VALID");
   const navigate = useNavigate();
 
+  // input박스 눌렀을 시에만 카운트 보이게
   const handleInputFocus = () => {
     setIsVisible(true);
   };
@@ -20,9 +21,10 @@ function SetupWorkspace() {
     setIsVisible(false);
   };
 
+  // 유효한 카운트 함수
   const handleValidate = (e) => {
     const lencount = e.target.value.length;
-    const maxLength = 10;
+    const maxLength = 50;
 
     setTeamName(e.target.value);
     setCharCount(maxLength - lencount);
@@ -234,7 +236,7 @@ function SetupWorkspace() {
                                   className="c-alert__message"
                                   data-qa-alert-message="true"
                                 >
-                                  10 자까지만 입력할 수 있습니다.
+                                  50 자까지만 입력할 수 있습니다.
                                 </span>
                               </div>
                             ) : null}

--- a/src/SetupWorkspace.js
+++ b/src/SetupWorkspace.js
@@ -45,7 +45,7 @@ function SetupWorkspace() {
     navigate("/setUpChannel");
   };
 
-  // 입력된 워크스페이스 이름 db저장
+  //입력된 워크스페이스 이름 db저장
   // const handleContinue = (e) => {
   //   e.preventDefault();
   //   if(validation === "VALID") {

--- a/src/SetupWorkspace.js
+++ b/src/SetupWorkspace.js
@@ -1,12 +1,16 @@
-import React, { useState } from "react";
+import axios from "axios";
+import React, { useState, useEffect } from "react";
 import { FiAlertTriangle } from "react-icons/fi";
+import { useNavigate } from "react-router-dom";
 import "./css/SetupWorkspace.css";
 
 function SetupWorkspace() {
-  const [value, setValue] = useState("새 워크스페이스");
+  const [teamName, setTeamName] = useState("새 워크스페이스");
   const [charcount, setCharCount] = useState(50);
   const [isAlert, setIsAlert] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
+  const [validation, setValidation] = useState("VALID");
+  const navigate = useNavigate();
 
   const handleInputFocus = () => {
     setIsVisible(true);
@@ -16,17 +20,46 @@ function SetupWorkspace() {
     setIsVisible(false);
   };
 
-  const onChange = (e) => {
+  const handleValidate = (e) => {
     const lencount = e.target.value.length;
     const maxLength = 50;
-    setValue(e.target.value);
+
+    setTeamName(e.target.value);
     setCharCount(maxLength - lencount);
+
     if (lencount > maxLength) {
       setIsAlert(true);
+      setValidation("INVALID");
+    } else if (lencount === 0) {
+      setValidation("EMPTY");
     } else {
       setIsAlert(false);
+      setValidation("VALID");
     }
   };
+  useEffect(() => {
+    console.log(`ws_name: ${teamName}`);
+  }, [teamName]);
+
+  const GotoSetupChannel = (e) => {
+    navigate("/setUpChannel");
+  };
+
+  // 입력된 워크스페이스 이름 db저장
+  // const handleContinue = (e) => {
+  //   e.preventDefault();
+  //   if(validation === "VALID") {
+  //     axios({
+  //       method: "post",
+  //       url: "",
+  //       data: { ws_name: teamName},
+  //     }).then({
+  //       navigate("/SetupChannel", {
+  //         state: {ws_name: teamName},
+  //       });
+  //     });
+  //   };
+  // };
 
   return (
     <div className="app_root">
@@ -50,8 +83,9 @@ function SetupWorkspace() {
                   >
                     <div className="p-ia__sidebar_header__info">
                       <div className="p-ia__sidebar_header__team_name">
+                        {/* 워크스페이스 이름 */}
                         <span className="p-ia__sidebar_header__team_name_text">
-                          {value}
+                          {teamName}
                         </span>
                       </div>
                     </div>
@@ -149,8 +183,8 @@ function SetupWorkspace() {
                               name="team-name"
                               placeholder="예: Acme 마케팅 또는 Acme"
                               type="text"
-                              value={value}
-                              onChange={onChange}
+                              value={teamName}
+                              onChange={handleValidate}
                               onFocus={handleInputFocus}
                               onBlur={handleInputBlur}
                               style={{ paddingRight: "42px" }}
@@ -170,7 +204,7 @@ function SetupWorkspace() {
                               </div>
                             ) : null}
 
-                            {isAlert ? (
+                            {isAlert && validation === "INVALID" ? (
                               <div
                                 className="c-alert c-alert--nested_box c-alert--level_error c-alert--align_left margin_bottom_100"
                                 id="setup-page-team-name_error"
@@ -203,6 +237,13 @@ function SetupWorkspace() {
                           data-qa="setup-page-team-name-submit"
                           aria-label="다음 단계로 이동"
                           type="submit"
+                          disabled={`${
+                            (isAlert && validation === "INVALID") ||
+                            validation === "EMPTY"
+                              ? "disabled"
+                              : ""
+                          }`}
+                          onClick={GotoSetupChannel}
                         >
                           다음
                         </button>

--- a/src/SignIn.js
+++ b/src/SignIn.js
@@ -16,11 +16,6 @@ function SignIn() {
   const [validation, setValidation] = useState("EMPTY");
   const navigate = useNavigate();
 
-  const onChange = (e) => {
-    setEmail(e.target.value);
-  };
-
-  // 오류: 이메일 @ 전에만 입력했을 때 알림 안뜸
   const handleValidate = () => {
     if (rEmail.test(email)) setValidation("VALID");
     else if (email === "") setValidation("EMPTY");
@@ -122,7 +117,7 @@ function SignIn() {
                   placeholder="name@work-email.com"
                   type="email"
                   value={email}
-                  onChange={onChange}
+                  onChange={(e) => setEmail(e.target.value)}
                 />
               </div>
               {isAlert && validation !== "VALID" ? (

--- a/src/components/LoginGoogle.js
+++ b/src/components/LoginGoogle.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import "../css/LoginGoogle.css";
 import { useNavigate } from "react-router-dom";
 import { GoogleLogin } from "react-google-login";
@@ -11,6 +11,11 @@ function LoginGoogle() {
 
   // 서버 요청
   const onLoginSuccess = (res) => {
+    // 브라우저 상에서 로그인한 사용자 이름 저장
+    // => 로그인 후에 워크스페이스 만드는 사용자 이름 저장 위함
+    const userName = { name: res.profileObj.name };
+    window.localStorage.setItem("userName", JSON.stringify(userName));
+    // window.localStorage.getItem("userName");
     axios({
       method: "post",
       url: "http://localhost:9000/api/auth/googleLogin",

--- a/src/css/SetupWorkspace.css
+++ b/src/css/SetupWorkspace.css
@@ -519,6 +519,10 @@ input {
   margin-top: 48px;
 }
 
+.margin_right {
+  margin-right: 20px;
+}
+
 .p-setup_page__content_button--aubergine {
   background-color: #4a154b;
 }

--- a/src/css/SetupWorkspace.css
+++ b/src/css/SetupWorkspace.css
@@ -469,6 +469,29 @@ input {
   -webkit-appearance: none;
   -webkit-tap-highlight-color: transparent;
 }
+.c-button:disabled {
+  background: rgba(var(--sk_foreground_low_solid, 221, 221, 221), 1);
+  color: rgba(var(--sk_primary_foreground, 29, 28, 29), 0.75);
+  cursor: default;
+  pointer-events: none;
+  text-shadow: none;
+  border-color: rgba(var(--sk_foreground_low_solid, 221, 221, 221), 1);
+  background-clip: initial;
+  box-shadow: none;
+  outline: none;
+  border: none;
+  border-radius: 4px;
+  margin-top: 48px;
+
+  min-width: 200px;
+  transition: none;
+  font-size: 18px;
+  font-weight: 900;
+  height: 44px;
+  padding: 0 16px 3px;
+  text-decoration: none;
+}
+
 .c-alert {
   display: flex;
 }

--- a/src/css/SetupWorkspace.css
+++ b/src/css/SetupWorkspace.css
@@ -212,6 +212,101 @@
   overflow-x: hidden;
   position: relative;
 }
+.c-virtual_list__item {
+  position: absolute;
+  width: 100%;
+  display: block;
+  box-sizing: inherit;
+  /* line-height: 1.46668;
+  font-weight: 400; */
+  font-variant-ligatures: common-ligatures;
+  -webkit-font-smoothing: antialiased;
+}
+.p-channel_sidebar--iap1 .p-channel_sidebar__section_heading,
+.p-drag_layer .p-channel_sidebar__section_heading {
+  height: 36px;
+}
+/* .p-channel_sidebar__section_heading_label {
+  box-sizing: inherit;
+  font-weight: 400;
+  display: block;
+  padding-top: 2rem;
+  padding-left: 1rem;
+} */
+
+.p-channel_sidebar__section_heading
+  .p-channel_sidebar__section_heading--setup-sidebar
+  .margin_top_200 {
+  background: #3f0e40;
+  text-align: center;
+  pointer-events: none;
+  height: 36px;
+  line-height: 28px;
+  padding: 0 16px;
+  /* padding-top: 2rem;
+  padding-left: 1rem; */
+  margin-top: 32px;
+  user-select: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border-radius: 0;
+  box-sizing: inherit;
+  font-size: 15px;
+}
+.p-channel_sidebar__static_list__item {
+  box-sizing: inherit;
+  display: block;
+  font-size: 15px;
+  /* line-height: 1.46668;
+  font-weight: 400;
+  /* line-height: 1.46668;
+  font-weight: 400;
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: elli;
+  font-size: 15px; */
+}
+
+.p-channel_sidebar__section_heading_label {
+  margin-left: 1rem;
+  margin-top: 2rem;
+  display: block;
+  opacity: 1;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  flex: 1 1 0;
+  padding-right: 8px;
+  transition: padding-right 0s ease-in-out 0.3s, color 0.1s ease-out 0s;
+}
+
+.p-channel_sidebar__channel {
+  box-sizing: inherit;
+  padding-left: 16px;
+  height: 28px;
+  line-height: 28px;
+  pointer-events: none;
+  user-select: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border-radius: 0;
+}
+.p-channel_sidebar__channel--setup {
+  padding-left: 16px;
+  pointer-events: none;
+}
+.p-channel_sidebar__name {
+  margin-right: 16px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  opacity: 1;
+}
 .c-scrollbar {
   position: relative;
   overflow: hidden;
@@ -233,7 +328,7 @@
 }
 .c-virtual_list__scroll_container {
   position: relative;
-  height: 0px;
+  height: 140px !important;
 }
 .c-scrollbar--hidden > .c-scrollbar__track {
   display: none;


### PR DESCRIPTION
## Done(~22-02-04)

- validate 확인 후 (글자 수 맞는지 확인) setupchannel로 이동

> 비어있거나 글자수 넘으면 버튼 비활성화(O), setup페이지를 2개로 나눴습니다.(setupworkspace, setupchannel)

- 페이지를 두개로 나눴으니, setupchannel페이지에서 이전 페이지(setupworkspace)로 돌아가 workspace이름 수정이 가능하게끔 버튼 생성

## Will(22-02-04~)
- state관리 -> workspace이름 유지한 상태에서 setupchannel페이지로 이동, setupchannel 페이지에서 채널명 적고 submit하면 workspace이름과 channel이름 db저장
> 네비게이트 인자로 넘기기, useLocation 

> Q. state값을 다른 js파일로 넘기고자 하려면 Reducer를 사용해야 하는지